### PR TITLE
Fix directory detection in .filenignore

### DIFF
--- a/src/renderer/lib/fs/local/fs-local.ts
+++ b/src/renderer/lib/fs/local/fs-local.ts
@@ -193,9 +193,10 @@ export const directoryTree = async (path: string, skipCache = false, location: L
 				}
 			}
 		} catch (e: any) {
+			const stats = await gracefulLStat(item.fullPath)
 			if (
-				!filenIgnoreCompiled.denies(item.path) &&
-				!filenIgnoreCompiled.denies(item.fullPath) &&
+				!filenIgnoreCompiled.denies(stats.isDir ? item.path + '/' : item.path) &&
+				!filenIgnoreCompiled.denies(stats.isDir ? item.fullPath + '/' : item.fullPath) &&
 				!isIgnoredBySelectiveSync(selectiveSyncRemote, item.path) &&
 				!isIgnoredBySelectiveSync(selectiveSyncRemote, item.fullPath)
 			) {

--- a/src/renderer/lib/worker/sync/sync.tasks.ts
+++ b/src/renderer/lib/worker/sync/sync.tasks.ts
@@ -42,9 +42,10 @@ export const sortTasks = async ({
 }): Promise<any> => {
 	const ignored = []
 	const [{ selectiveSyncRemoteIgnore, filenIgnore }, syncMode] = await Promise.all([getIgnored(location), getSyncMode(location)])
+	const filenIgnoreDenies = (task: any) => filenIgnore.denies(task.type == "folder" ? task.path + '/' : task.path)
 
 	for (let i = 0; i < renameInLocal.length; i++) {
-		if (filenIgnore.denies(renameInLocal[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, renameInLocal[i].path)) {
+		if (filenIgnoreDenies(renameInLocal[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, renameInLocal[i].path)) {
 			ignored.push(renameInLocal[i].path)
 			renameInLocal.splice(i, 1)
 
@@ -53,7 +54,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < renameInRemote.length; i++) {
-		if (filenIgnore.denies(renameInRemote[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, renameInRemote[i].path)) {
+		if (filenIgnoreDenies(renameInRemote[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, renameInRemote[i].path)) {
 			ignored.push(renameInRemote[i].path)
 			renameInRemote.splice(i, 1)
 
@@ -62,7 +63,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < moveInLocal.length; i++) {
-		if (filenIgnore.denies(moveInLocal[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, moveInLocal[i].path)) {
+		if (filenIgnoreDenies(moveInLocal[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, moveInLocal[i].path)) {
 			ignored.push(moveInLocal[i].path)
 			moveInLocal.splice(i, 1)
 
@@ -71,7 +72,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < moveInRemote.length; i++) {
-		if (filenIgnore.denies(moveInRemote[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, moveInRemote[i].path)) {
+		if (filenIgnoreDenies(moveInRemote[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, moveInRemote[i].path)) {
 			ignored.push(moveInRemote[i].path)
 			moveInRemote.splice(i, 1)
 
@@ -80,7 +81,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < deleteInLocal.length; i++) {
-		if (filenIgnore.denies(deleteInLocal[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, deleteInLocal[i].path)) {
+		if (filenIgnoreDenies(deleteInLocal[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, deleteInLocal[i].path)) {
 			ignored.push(deleteInLocal[i].path)
 			deleteInLocal.splice(i, 1)
 
@@ -89,7 +90,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < deleteInRemote.length; i++) {
-		if (filenIgnore.denies(deleteInRemote[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, deleteInRemote[i].path)) {
+		if (filenIgnoreDenies(deleteInRemote[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, deleteInRemote[i].path)) {
 			ignored.push(deleteInRemote[i].path)
 			deleteInRemote.splice(i, 1)
 
@@ -98,7 +99,7 @@ export const sortTasks = async ({
 	}
 
 	for (let i = 0; i < uploadToRemote.length; i++) {
-		if (filenIgnore.denies(uploadToRemote[i].path) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, uploadToRemote[i].path)) {
+		if (filenIgnoreDenies(uploadToRemote[i]) || isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, uploadToRemote[i].path)) {
 			ignored.push(uploadToRemote[i].path)
 			uploadToRemote.splice(i, 1)
 
@@ -108,7 +109,7 @@ export const sortTasks = async ({
 
 	for (let i = 0; i < downloadFromRemote.length; i++) {
 		if (
-			filenIgnore.denies(downloadFromRemote[i].path) ||
+			filenIgnoreDenies(downloadFromRemote[i]) ||
 			isIgnoredBySelectiveSync(selectiveSyncRemoteIgnore, downloadFromRemote[i].path)
 		) {
 			ignored.push(downloadFromRemote[i].path)


### PR DESCRIPTION
Due to a usage limitation in `@gerhobbelt/gitignore-parser`, directory patterns with a trailing slash in the .filenignore do not work as expected. This PR fixes this issue.

# Details
The .gitignore syntax utilized for the .filenignore syntax supports three different ways of excluding directories.
> 1. `/dir` will match a file, directory, link, anything named dir
> 1. `/dir/` will match only a directory named dir
> 1. `/dir/*` will match all files, directories and anything else inside a directory named dir (but not the dir directory itself).

Source: https://stackoverflow.com/questions/17888695/#answer-38559600

The second item of the list above is not currently supported by Filen, resulting in the directory `/dir/` to still be uploaded. This happens, because `@gerhobbelt/gitignore-parser` cannot deduce whether a path is a directory or file when matching it against the pattern. The proposed solution is to append directory paths with a trailing slash, see https://www.npmjs.com/package/@gerhobbelt/gitignore-parser#notes

# Implementation
Here, I have sought out (I believe) all usages of `@gerhobbelt/gitignore-parser` and before passing a path to the `denies` method, added a trailing slash, if the path is a directory.

I tested the changes locally and found the changes to have the desired effects. Nevertheless, I encourage formal testing as I could not find a testsuite and only build and tested the application on windows. I welcome suggestions for edits.