### PR TITLE
Feature proposal: Physical .filenignore file

### DIFF
--- a/src/renderer/lib/worker/sync/sync.utils.ts
+++ b/src/renderer/lib/worker/sync/sync.utils.ts
@@ -5,6 +5,8 @@ import { Location, SyncModes } from "../../../../types"
 
 const log = window.require("electron-log")
 const gitignoreParser = window.require("@gerhobbelt/gitignore-parser")
+const fs = window.require("fs-extra")
+const pathModule = window.require("path")
 
 export const isSyncLocationPaused = async (uuid: string): Promise<boolean> => {
 	try {
@@ -52,6 +54,11 @@ export const getIgnored = (
 			.then(([selectiveSyncRemote, fIgnore]) => {
 				if (typeof fIgnore !== "string") {
 					fIgnore = ""
+				}
+
+				const physicalIgnoreFile = pathModule.join(location.local, ".filenignore")
+				if (fs.existsSync(physicalIgnoreFile)) {
+					fIgnore += "\n" + fs.readFileSync(physicalIgnoreFile, "utf-8")
 				}
 
 				try {


### PR DESCRIPTION
**Proposed feature:** This pull request proposes adding the option of having a "physical" `.filenignore` file located at the root of a sync location. Its content is added to the content of the "virtual" .filenignore loaded from the local database. 

**Advantages:** Additionally to the current "virtual" implementation, this allows the .filenignore file to be uploaded along with the files of a sync location, and thus for it to be downloaded along with the files when syncing to another device. (This is very useful for e. g. JavaScript source repositories where `node_modules` mustn't be uploaded to cloud storage on any device that clones the sync location locally.)

Note: My solution here is rather hacky, and it currently only supports a `.filenignore` at the root of a sync location. On the other hand, this implementation is extremely compact (so it doesn't clutter up the code and can be removed easily) and it being there probably will not bother the end user much. 