### PR TITLE
fix: updated appimage runtime through electron-builder config

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,6 +262,9 @@
 		},
 		"dmg": {
 			"sign": false
+		},
+		"toolsets": {
+			"appimage": "1.0.3"
 		}
 	}
 }


### PR DESCRIPTION
Fedora has removed fuse 2 from their atomic images in April, because of the tool being unmaintained for a long time. Yet a Cloud Storage application which advertises the security of their platform has not cared to update their application for 2 months to resolve this issue.

The fix was amusingly 3 lines to the electron-builder config, yet nobody bothered to add this for 2 months. Please at least merge this pull request since I had to create a fork for 3 lines of json.